### PR TITLE
increase opacity for attribution background

### DIFF
--- a/assets/control.layers.minimap.custom.css
+++ b/assets/control.layers.minimap.custom.css
@@ -1,0 +1,2 @@
+.leaflet-container .leaflet-control-attribution {
+    background: rgba(255, 255, 255, 0.85);


### PR DESCRIPTION
Pour une meilleure lisibilité des attributions, en particulier quand un texte noir de la carte est placé dessous.

![opacity-0 7](https://user-images.githubusercontent.com/9863567/52805616-418d2c80-3087-11e9-8650-a79940eb3bd4.png) ![opacity-0 85](https://user-images.githubusercontent.com/9863567/52805617-418d2c80-3087-11e9-9541-3ad982311331.png)

Sera encore plus visible et important avec des textes d'attribution plus détaillés
