### PR TITLE
css control for responsive minimaps

### DIFF
--- a/assets/control.layers.minimap.custom.css
+++ b/assets/control.layers.minimap.custom.css
@@ -1,3 +1,36 @@
 .leaflet-container .leaflet-control-attribution {
     background: rgba(255, 255, 255, 0.85);
 }
+.leaflet-control-layers-expanded.leaflet-control-layers-minimap {
+    width: 30%;
+    min-width: 180px;
+    max-width: 440px;
+    min-height: 180px;
+    max-height: 100%;
+}
+@media only screen and (max-width: 556px) {
+  /* For small screens: */
+  .leaflet-control-layers-expanded.leaflet-control-layers-minimap {
+    width: 50%;
+    height: 40%;
+  }
+}
+@media only screen and (max-width: 556px) and (max-height: 400px),
+ only screen and (max-width: 400px) {
+  /* For small screens: */
+  .leaflet-control-layers-expanded.leaflet-control-layers-minimap {
+    width: 40%;
+    height: 40%;
+  }
+}
+@media  only screen and (max-width: 230px),
+ only screen and (max-width: 260px) and (max-height: 600px),
+ only screen and (max-width: 300px) and (max-height: 500px),
+ only screen and (max-width: 350px) and (max-height: 400px),
+ only screen and (max-width: 400px) and (max-height: 300px),
+ only screen and (max-height: 200px) {
+  /* For very small screens: */
+  .leaflet-control-layers-expanded.leaflet-control-layers-minimap {
+    display: none;
+  }
+}


### PR DESCRIPTION
La taille des minimaps varie maintenant en fonction de la taille de la carte.
On évite ainsi d'avoir une trop grande partie de la carte occulté par le panneau des minimaps.
En cas de besoin, avec une carte trop petite, les minimaps sont cachées.

